### PR TITLE
Account metadata - csv, xlsx, gnucash 

### DIFF
--- a/financespy/account.py
+++ b/financespy/account.py
@@ -1,17 +1,105 @@
 import datetime
+import os
+from pathlib import Path
+import json
+from dataclasses import dataclass
+
+from financespy.xlsx_backend import XLSXBackend
+from financespy.filesystem_backend import FilesystemBackend
+from financespy.categories import Categories
+from financespy.categories import categories_from_list
 
 _current_year = datetime.datetime.now().year
 
+class OpenAccountError(Exception):
+
+    def __init__(self, message):
+        self.message = message
+
+def open_account(account_path = None):
+    if account_path is None:
+        return open_default_account()
+
+    if os.path.isdir(account_path):
+        return open_folder(account_path)
+
+    # we only support gnucash files
+    try:
+        dot_index = account_path.rindex(".")
+        extension = account_path[-dot_index:]
+
+        if extension == ".gnucash":
+            return open_gnucash(account_path)
+
+        raise Exception()
+    except:
+        raise OpenAccountError(f"File [{account_path}] is not a valid Gnucash file")
+
+
+def open_folder(account_path):
+    account_json = Path(account_path) / "account.json"
+
+    if not account_json.exists():
+        raise OpenAccountError(f"account.json file not found at folder [{account_json}]")
+
+    account_metadata = read_metadata(account_json)    
+
+    if not account_metadata.backend_type:
+        raise OpenAccountError(f"Account backend type not specified in account.json file")
+
+    backend = None
+    
+    if account_metadata.backend_type == "xlsx":
+        backend = XLSXBackend(account_path)
+    elif account_metadata.backend_type == "csv":
+        backend = FilesystemBackend(account_path)
+
+    if backend is None:
+        raise OpenAccountError(f"Account backend type [{account_metadata.type} not supported]")
+
+    return Account(backend, account_metadata)
+
+def read_metadata(account_json):
+    with open(account_json) as f:
+        source_dict = json.load(f)
+        backend_type = source_dict.get("type", "")
+        categories = source_dict.get("categories", [])
+        currency = source_dict.get("currency", "")
+        
+        return AccountMetadata(
+            backend_type=backend_type,
+            categories=categories_from_list(categories),
+            currency=currency
+        )
+
+
+def open_gnucash(gnucash_file):
+    pass
+
+@dataclass
+class AccountMetadata:
+    backend_type: str
+    currency: str
+    categories: Categories
+
 
 class Account:
-    def __init__(self, backend):
+    def __init__(self, backend, account_metadata):
+        backend.categories = account_metadata.categories
+        backend.currency = account_metadata.currency
+        
         self._backend = backend
+        self._metadata = account_metadata
+        
 
     def day(self, day, month, year=_current_year):
         return self._backend.day(day, month, year)
 
     def month(self, month, year=_current_year):
         return self._backend.month(month, year)
+
+    def records(self, date):
+        return self._backend.records(date)
 
     def insert_record(self, date, transaction):
         self._backend.insert_record(date, transaction)

--- a/financespy/account.py
+++ b/financespy/account.py
@@ -32,7 +32,7 @@ def open_account(account_path = None):
     try:
         dot_index = account_path.rindex(".")
         extension = account_path[-(len(account_path)-dot_index):]
-    except:
+    except ValueError as err:
         pass
 
     if extension == ".gnucash":

--- a/financespy/account.py
+++ b/financespy/account.py
@@ -32,7 +32,7 @@ def open_account(account_path = None):
     try:
         dot_index = account_path.rindex(".")
         extension = account_path[-(len(account_path)-dot_index):]
-    except ValueError as err:
+    except ValueError:
         pass
 
     if extension == ".gnucash":

--- a/financespy/account.py
+++ b/financespy/account.py
@@ -2,17 +2,20 @@ import datetime
 import os
 from pathlib import Path
 import json
+import re
 from dataclasses import dataclass
-
+from financespy import gnucash_backend
+from financespy.gnucash_backend import GnucashBackend
 from financespy.xlsx_backend import XLSXBackend
 from financespy.filesystem_backend import FilesystemBackend
 from financespy.categories import Categories
 from financespy.categories import categories_from_list
 
+
 _current_year = datetime.datetime.now().year
 
 class OpenAccountError(Exception):
-
+    
     def __init__(self, message):
         self.message = message
 
@@ -24,16 +27,19 @@ def open_account(account_path = None):
         return open_folder(account_path)
 
     # we only support gnucash files
+    extension = None
+    
     try:
         dot_index = account_path.rindex(".")
-        extension = account_path[-dot_index:]
-
-        if extension == ".gnucash":
-            return open_gnucash(account_path)
-
-        raise Exception()
+        extension = account_path[-(len(account_path)-dot_index):]
     except:
-        raise OpenAccountError(f"File [{account_path}] is not a valid Gnucash file")
+        pass
+
+    if extension == ".gnucash":
+        return open_gnucash(account_path)
+
+    raise OpenAccountError(f"File [{account_path}] is not a valid Gnucash file")
+
 
 
 def open_folder(account_path):
@@ -62,25 +68,59 @@ def open_folder(account_path):
 def read_metadata(account_json):
     with open(account_json) as f:
         source_dict = json.load(f)
+        name = source_dict.get("name", "")
         backend_type = source_dict.get("type", "")
         categories = source_dict.get("categories", [])
         currency = source_dict.get("currency", "")
+        properties = source_dict.get("properties", {})
         
         return AccountMetadata(
+            name=name,
             backend_type=backend_type,
             categories=categories_from_list(categories),
-            currency=currency
+            currency=currency,
+            properties=properties
         )
 
 
 def open_gnucash(gnucash_file):
-    pass
+    from gnucash import Session
+    
+    path = Path(gnucash_file)
+    metadata_file = re.sub('[.]gnucash$', ".json", path.name)
+    metadata = read_metadata(str(path.parent / metadata_file))
+
+    session = Session(gnucash_file)
+    
+    gnucash_account = gnucash_backend.account_for(
+        session,
+        metadata.properties['account_backend']
+    )
+
+    if not metadata.categories:
+        metadata.categories = gnucash_backend.categories_from(
+            session,
+            metadata.properties['account_categories']
+        )
+
+    backend = GnucashBackend(
+        session=session,
+        account=gnucash_account
+    )
+
+    return Account(
+        backend,
+        metadata
+    )
+
 
 @dataclass
 class AccountMetadata:
+    name: str
     backend_type: str
     currency: str
     categories: Categories
+    properties: dict
 
 
 class Account:
@@ -88,21 +128,21 @@ class Account:
         backend.categories = account_metadata.categories
         backend.currency = account_metadata.currency
         
-        self._backend = backend
-        self._metadata = account_metadata
+        self.backend = backend
+        self.metadata = account_metadata
         
 
     def day(self, day, month, year=_current_year):
-        return self._backend.day(day, month, year)
+        return self.backend.day(day, month, year)
 
     def month(self, month, year=_current_year):
-        return self._backend.month(month, year)
+        return self.backend.month(month, year)
 
     def records(self, date):
-        return self._backend.records(date)
+        return self.backend.records(date)
 
     def insert_record(self, date, transaction):
-        self._backend.insert_record(date, transaction)
+        self.backend.insert_record(date, transaction)
 
     def copy_year(self, account, year, tags=[], filters=[]):
         for month in range(1, 13):

--- a/financespy/backend.py
+++ b/financespy/backend.py
@@ -28,6 +28,12 @@ class Backend:
                 if _satisfy_filters(record, filters):
                     self.insert_record(record.date, record)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
 
 class CompositeBackend:
 

--- a/financespy/backend.py
+++ b/financespy/backend.py
@@ -32,6 +32,7 @@ class Backend:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        '''Empty exit method for allowing any backend to be used in a with block'''
         pass
 
 

--- a/financespy/categories.py
+++ b/financespy/categories.py
@@ -37,30 +37,10 @@ class Categories:
             self._default
         )
 
-
-def _categories_from_list(cats):
-
-    def aux(catmap, cats, parent):
-        for cat in cats:
-            if type(cat) is str:
-                category = Category(
-                    cat,
-                    parent
-                )
-                catmap[cat] = category
-            elif type(cat) is tuple:
-                category = Category(
-                    cat[0],
-                    parent
-                )
-                catmap[cat[0]] = category
-                aux(catmap, cat[1], category)
-
-    catmap = {}
-    aux(catmap, cats, None)
-    return Categories(catmap, catmap["uncategorized"])
-
 def categories_from_list(cats):
+
+    if not cats:
+        return None
     
     def aux(catmap, cats, parent):
         for cat in cats:

--- a/financespy/categories.py
+++ b/financespy/categories.py
@@ -38,7 +38,7 @@ class Categories:
         )
 
 
-def categories_from_list(cats):
+def _categories_from_list(cats):
 
     def aux(catmap, cats, parent):
         for cat in cats:
@@ -55,6 +55,29 @@ def categories_from_list(cats):
                 )
                 catmap[cat[0]] = category
                 aux(catmap, cat[1], category)
+
+    catmap = {}
+    aux(catmap, cats, None)
+    return Categories(catmap, catmap["uncategorized"])
+
+def categories_from_list(cats):
+    
+    def aux(catmap, cats, parent):
+        for cat in cats:
+            if type(cat) is str:
+                category = Category(
+                    cat,
+                    parent
+                )
+                catmap[cat] = category
+            elif type(cat) is dict:
+                cat_name = cat.keys().__iter__().__next__()                
+                category = Category(
+                    cat_name,
+                    parent
+                )
+                catmap[cat_name] = category
+                aux(catmap, cat[cat_name], category)
 
     catmap = {}
     aux(catmap, cats, None)

--- a/financespy/xlsx_backend.py
+++ b/financespy/xlsx_backend.py
@@ -5,11 +5,10 @@ from financespy.backend import Backend
 
 
 class XLSXBackend(Backend):
-    def __init__(self, folder, categories):
+    def __init__(self, folder):
         super().__init__()
         self.folder = folder
         self._workbooks = {}
-        self._categories = categories
 
     def _filename(self, date):
         return self.folder + "/" + str(date.year) + ".xlsx"
@@ -30,7 +29,7 @@ class XLSXBackend(Backend):
                 str(row[2].value)
                 + ","
                 + str(row[1].value),
-                self._categories
+                self.categories
             )
             for row in list(rows)[1:]
             if row[0].value and date.day == int(row[0].value)

--- a/tests/resources/finances/account.json
+++ b/tests/resources/finances/account.json
@@ -1,9 +1,7 @@
-import datetime
-from financespy import categories
-
-def get_categories():
-
-    default_categories = [
+{
+    "type": "xlsx",
+    "currency": "eur",
+    "categories": [
         "misc",
         "uncategorized",
         {"food": [
@@ -14,18 +12,9 @@ def get_categories():
         {"utilities": ["internet", "electricity", "cellphone_balance"]},
         {"travel": ["plane_ticket", "hotel_reservation", "train_ticket"]},
         {"tax": ["tv_tax"]},
-        {"shopping": ["electronics", "clothing", "sports", "home_goods",
-                      "furniture", "shopping_misc", "shoes", "purses", "jewlery"]},
+        {"shopping": ["electronics", "clothing", "sports", "home_goods", "furniture", "shopping_misc", "shoes", "purses", "jewlery"]},
         {"education": [{"course_fee": ["german_course"]}, "textbook", "school_supplies"]},
         {"body_and_hygiene": ["perfume", "hair_product", "hairdresser", "nails"]},
         {"commuting": ["monthly_ticket", "day_ticket", "single_ticket"]}
     ]
-
-    return categories.categories_from_list(default_categories)
-
-def dt(day, month, year = 2019):
-    return datetime.date(
-        day = day,
-        month = month,
-        year = year
-    )
+}

--- a/tests/resources/gnucash/myacc.json
+++ b/tests/resources/gnucash/myacc.json
@@ -1,0 +1,8 @@
+{
+	"type": "gnucash",
+	"currency": "EUR",
+	"properties": {
+		"account_backend": "Assets/Current Assets/Checking Account",
+		"account_categories": "Expenses"
+	}
+}

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -6,15 +6,15 @@ def get_categories():
     default_categories = [
         "misc",
         "uncategorized",
-        ("food", [("groceries", ["lidl", "aldi", "edeka", "rewe"]),
+        {"food": [{"groceries": ["lidl", "aldi", "edeka", "rewe"]},
                   "restaurant",
-                  "street_food"]),
-        ("utilities", ["internet",
+                  "street_food"]},
+        {"utilities": ["internet",
                        "electricity",
-                       "cellphone_balance"]),
-        ("travel", ["plane_ticket", "hotel_reservation", "train_ticket"]),
-        ("tax", ["tv_tax"]),
-        ("shopping", [
+                       "cellphone_balance"]},
+        {"travel": ["plane_ticket", "hotel_reservation", "train_ticket"]},
+        {"tax": ["tv_tax"]},
+        {"shopping": [
             "electronics",
             "clothing",
             "sports",
@@ -23,17 +23,17 @@ def get_categories():
             "shopping_misc",
             "shoes",
             "purses",
-            "jewlery"]),
-        ("education", [
-            ("course_fee", ["german_course"]),
+            "jewlery"]},
+        {"education": [
+            {"course_fee": ["german_course"]},
             "textbook",
-            "school_supplies"]),
-        ("body_and_hygiene", [
+            "school_supplies"]},
+        {"body_and_hygiene": [
             "perfume",
             "hair_product",
             "hairdresser",
-            "nails"]),
-        ("commuting", ["monthly_ticket", "day_ticket", "single_ticket"])
+            "nails"]},
+        {"commuting": ["monthly_ticket", "day_ticket", "single_ticket"]}
     ]
 
     return categories.categories_from_list(default_categories)

--- a/tests/test_gnucashbackend.py
+++ b/tests/test_gnucashbackend.py
@@ -1,6 +1,8 @@
 import os
+import pytest
 from datetime import datetime
 from gnucash import Session
+from financespy.account import open_account
 from financespy.gnucash_backend import GnucashBackend
 from financespy.gnucash_backend import categories_from
 from financespy.transaction import parse_transaction
@@ -42,54 +44,32 @@ def total_iterator(iterator):
 
 def test_insert_records():
     os.system("cp -R ./tests/resources/gnucash ./gnucash")
+    
+    try:
+        account = open_account("./gnucash/myacc.gnucash")
+        
+        backend = account.backend
+        session = account.backend._session
+        categories = backend.categories
+        memory_backend = MemoryBackend(categories)
+        
+        # populating backends
+        for date, rec in records(categories):
+            backend.insert_record(date, rec)
+            memory_backend.insert_record(date, rec)
+            
+        # assert we read the same in both backends
+        weeks1 = backend.month("sep", 2019).weeks()
+        weeks2 = memory_backend.month("sep", 2019).weeks()
+        
+        assert total_iterator(weeks1) == total_iterator(weeks2)
+        
+        month1 = backend.month("sep", 2019).days()
+        month2 = memory_backend.month("sep", 2019).days()
+        
+        assert total_iterator(month1) == total_iterator(month2)
 
-    # setting up gnucash backend
-    session = Session('./gnucash/myacc.gnucash')
-    assets = session.book.get_root_account()["Assets"]
-    checking_account = assets["Current Assets"]["Checking Account"]
-    expenses_account = session.book.get_root_account()["Expenses"]
-    categories = categories_from(expenses_account)
-
-    # creating backends
-    backend = GnucashBackend(
-        session=session,
-        account=checking_account,
-        categories=categories,
-        currency="EUR"
-    )
-
-    memory_backend = MemoryBackend(categories)
-
-    # populating backends
-    for date, rec in records(categories):
-        backend.insert_record(date, rec)
-        memory_backend.insert_record(date, rec)
-
-    # assert we read the same in both backends
-    weeks1 = backend.month("sep", 2019).weeks()
-    weeks2 = memory_backend.month("sep", 2019).weeks()
-
-    assert total_iterator(weeks1) == total_iterator(weeks2)
-
-    month1 = backend.month("sep", 2019).days()
-    month2 = memory_backend.month("sep", 2019).days()
-
-    assert total_iterator(month1) == total_iterator(month2)
-
-    session.save()
-    session.end()
-    os.system("rm -rf ./gnucash")
-
-
-def aaa_test_listrecords():
-    session = Session('/home/danilo/Documents/my_account.gnucash')
-    assets = session.book.get_root_account()["Assets"]
-    checking_account = assets["Current Assets"]["Checking Account"]
-    expenses_account = session.book.get_root_account()["Expenses"]
-    categories = categories_from(expenses_account)
-    backend = GnucashBackend(session, checking_account, categories)
-
-    for t in backend.month(month=9, year=2019).records():
-        print((t, t.date))
-
-    session.end()
+        session.save()
+        session.end()
+    finally:
+        os.system("rm -rf ./gnucash")

--- a/tests/test_xlsx_backend.py
+++ b/tests/test_xlsx_backend.py
@@ -1,3 +1,4 @@
+from financespy.account import open_account
 from financespy.transaction import parse_transaction
 from financespy.xlsx_backend import XLSXBackend
 from tests.test_utils import get_categories
@@ -7,7 +8,12 @@ import os
 
 def backend(path="./tests/resources/finances"):
     cats = get_categories()
-    return XLSXBackend(path, cats)
+    backend = XLSXBackend(path)
+    
+    backend.categories = cats
+    backend.currency = "eur"
+
+    return backend
 
 
 def list_records(be, date_):
@@ -15,6 +21,19 @@ def list_records(be, date_):
         (str(trans.main_category()), float(trans.value))
         for trans in be.records(date_)
     ]
+
+def test_open_xlsx_account():
+    account = open_account("./tests/resources/finances")
+
+    records = list_records(account, dt(day=3, month=1))
+    expected = [
+        ("street_food", 34),
+        ("sports", 467),
+        ("furniture", 43)
+    ]
+
+    assert records == expected
+    assert not list(account.records(dt(day=1, month=12)))
 
 
 def test_list_records():


### PR DESCRIPTION
Account metadata is added for the mentioned backends. It uses the following convention:

- For cvs and xlsx, which are folder-based, the account metadata is stored in a file named "account.json", inside the storage folder
- For gnucash files, the account metadata is a json file with the same base name, replacing the extension "gnucash" with "json", in the same folder

This convention may change slightly in the future.